### PR TITLE
added uglifyjs parsing of header/footer files

### DIFF
--- a/bin/jessie
+++ b/bin/jessie
@@ -32,7 +32,10 @@ var footer = fs.readFileSync(program.footer, "utf8");
 
 var HEADER_DECLARATIONS = [];
 
+// parse the header/footer using uglify
 var ast = jsp.parse(header + footer);
+
+// walk over the ast looking for `var` declarations to add to HEADER_DECLARATIONS
 var w = pro.ast_walker();
 ast = w.with_walkers({
 	"var": function (defs) {


### PR DESCRIPTION
This is used to determine the variables that are declared in the header file so that they can be exported to the global scope

It helps with error checking if a user decides to use a different header file
